### PR TITLE
DH modes now orthogonal also with central obstruction

### DIFF
--- a/yaodh.i
+++ b/yaodh.i
@@ -99,9 +99,11 @@ func make_diskharmonic(size,diameter,ndhmodes,xc=,yc=,disp=,cobs=)
   write,"";
 
   // Introduce radial scaling to keep modes orthogonal
-  normcoef = sum(pupil) / sum(radmod *pupil)
-  for (i1=1; i1<=ndhmodes; i1++) {
-    dh_tab(,,i1) = dh_tab(,,i1) * radmod *pupil * normcoef
+  if (cobs) {
+    normcoef = sum(pupil) / sum(radmod *pupil)
+      for (i1=1; i1<=ndhmodes; i1++) {
+        dh_tab(,,i1) = dh_tab(,,i1) * radmod *pupil * normcoef
+      }
   }
 
   // Test that everything went well


### PR DESCRIPTION
The DH modes should now be orthogonal with also central obstruction.  A radial scaling is applied that adjusts the modified integration range.

Tested with small number (up to 40 modes). 
