### PR TITLE
Minor fix for case of empty nok array

### DIFF
--- a/yao.i
+++ b/yao.i
@@ -2682,7 +2682,6 @@ func aoinit(disp=,clean=,forcemat=,svd=,dpi=,keepdmconfig=,external_actpos=)
           
 
           dm(nm)._indval = &ok;
-          dm(nm)._indext = &nok;
 
           dm(nm)._x = &(dmx(ok));
           dm(nm)._y = &(dmy(ok));
@@ -2692,6 +2691,8 @@ func aoinit(disp=,clean=,forcemat=,svd=,dpi=,keepdmconfig=,external_actpos=)
           }
 
           if (numberof(nok) == 0) continue; //yes, it should be here.
+
+          dm(nm)._indext = &nok;
 
           dm(nm)._ex = &(dmx(nok));
           dm(nm)._ey = &(dmy(nok));


### PR DESCRIPTION
Not the most elegant fix but it does the job. Works when (numberof(nok) >= 0). Previously an error would occur if (numberof(nok) == 0) because the empty array has no address.