### PR TITLE
updated URL of docs to github.io rather than github.com

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@ AO loop. The core functions are written in C, hence are very fast.
 
 Help pages:
 -----------
-http://frigaut.github.io/yao/
+https://frigaut.github.io/yao/
 
 RELEASE NOTES:
 --------------

--- a/README
+++ b/README
@@ -22,7 +22,7 @@ AO loop. The core functions are written in C, hence are very fast.
 
 Help pages:
 -----------
-http://frigaut.github.com/yao/index.html
+http://frigaut.github.io/yao/
 
 RELEASE NOTES:
 --------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Aurea Garcia-Rissmann   agrissmann@gmail.com
 Yao is a Monte-Carlo simulation tool for Adaptive optics (AO) systems, written as a yorick plugin. It uses a number of custom developed functions to simulate wavefront sensors (WFS), deformable mirrors (DM) and many other aspects of an AO loop. The core functions are written in C, hence are very fast.
 
 ## Help pages
-http://frigaut.github.com/yao/index.html
+http://frigaut.github.io/yao/
 
 ## Required Dependencies
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Aurea Garcia-Rissmann   agrissmann@gmail.com
 Yao is a Monte-Carlo simulation tool for Adaptive optics (AO) systems, written as a yorick plugin. It uses a number of custom developed functions to simulate wavefront sensors (WFS), deformable mirrors (DM) and many other aspects of an AO loop. The core functions are written in C, hence are very fast.
 
 ## Help pages
-http://frigaut.github.io/yao/
+https://frigaut.github.io/yao/
 
 ## Required Dependencies
 


### PR DESCRIPTION
Github doesn't support _github.com_ subdomains any more, but all the docs that used to live there can now be found at an equivalent _github.io_ domain. Additionally to this pull request, the "about" section of this git repo should be changed to point to [https://frigaut.github.io/yao/](https://frigaut.github.io/yao/) (rather than [http://frigaut.github.com/yao/index.html](http://frigaut.github.com/yao/index.html), as it does currently).